### PR TITLE
Remove set -e - fails on source

### DIFF
--- a/inst/lang/bash_socket.bash
+++ b/inst/lang/bash_socket.bash
@@ -2,7 +2,6 @@
 #
 # Server for bash <--> R
 #
-set -e
 
 token=$1
 port=$2


### PR DESCRIPTION
Hi Yihui, I'm trying runr again. I'm trying to execute a bash command  of "source /path/to/my/script" . This doesn't return an exit status. Because bash_socket.bash has a "set -e" in it, the socket script quits when it tries to run the source command. 

I've fixed this by removing the "set -e" from bash_socket.bash . I don't think you need it -- if there's an error in the command that is executed, the error message will get returned and the user will see it. This is better than bash_socket.bash exiting on error, which hangs the knit command.  Thanks! - Adam
