### PR TITLE
V8 engine for knitr

### DIFF
--- a/R/V8engine.R
+++ b/R/V8engine.R
@@ -1,0 +1,46 @@
+# group source lines into complete expressions (using a brutal-force method)
+group_src_V8 = function(code, context) {
+  if ((n <- length(code)) < 1) return(list(code))
+  i = i1 = i2 = 1
+  x = list()
+  while (i2 <= n) {
+    piece = code[i1:i2]
+    if (context$validate(piece) &&  context$eval(piece)!="undefined") {
+      x[[i]] = piece; i = i + 1
+      i1 = i2 + 1 # start from the next line
+    }
+    i2 = i2 + 1
+  }
+  if (i1 <= n) parse(text = piece)  # must be an error there
+  x
+}
+
+# V8 engine - use in knitr by setting knit_engines$set(V8=V8engine)
+V8engine <- function(options) {
+  require(V8)
+  if(!exists(".context")){
+    if(is.null(options$V8.context)){
+      assign(".context", new_context(), envir = .GlobalEnv)
+    }else{
+      .context <<- options$V8.context
+    }
+    if(!is.null(options$V8.libraries)){
+      for(library in options$V8.libraries){
+        .context$source(library)
+      }
+    }
+  }
+  code <- as.character(c(options$code))
+  if(!.context$validate(code)) stop("unvalid javascript code")
+  if(!is.element(options$results, c("hide", "last"))){
+    code <- group_src_V8(code, .context)
+    output <- sapply(code, function(code) .context$eval(code))
+    code <-  sapply(code, function(code) knitr:::wrap.source(list(src= paste(code, collapse = "\n")), options))
+  }else{
+    if(options$results=="last") output <- .context$eval(code)
+    code <-  knitr:::wrap.source(list(src= paste(code, collapse = "\n")), options)
+    if(options$results=="hide") return(code)
+    return(c(code, knitr:::wrap.character(output, options)))
+  }
+  return(c(sapply(seq_along(code), function(i) c(code[i], knitr:::wrap.character(output[i], options)))))
+}


### PR DESCRIPTION
This is a V8 engine for knitr. An example of use is given below. It works, but there are surely many things to improve (I don't master the knitr machinery).

```
```{r}
library(knitr)
knit_engines$set(V8 = runr:::V8engine)
```

By default the Javascript context is a R variable named `.context`. You can set another name by doing `opts_chunk$set(V8.context=mycontext)`. For instance:
```{r}
library(V8)
ct <- new_context()
opts_chunk$set(V8.context=ct)
```

For example, we write the Javascript code below in a chunk with the option `engine='V8'`:

```
var x=[]
for(i = 0; i<3; i++){
  x[i]=i;
}
x.push([3,4])
JSON.stringify(x)
```

See it in action:

```{r, engine='V8'}
var x=[]
for(i = 0; i<3; i++){
  x[i]=i;
}
x.push([3,4])
JSON.stringify(x)
```

In the previous chunk, the `results` option is set to its default value. You can use `results='hide'` to hide the output, or `results='last'` to show only the output generated by the last line:

```{r, engine='V8', results='last'}
// this chunk has the options engine='V8' and results='last'
var x=[]
x.push([1,2])
x.push([3,4])
JSON.stringify(x)
```


Using the context variable you can import a variable from the Javascript context to R or vice-versa (see `?V8::V8` for details) :

- Get `x` in R :

```{r}
( x.in.R <- ct$get("x") )
```

- Double `x` in R and assign in Javascript context :

```{r}
ct$assign("double_x", 2*x.in.R)
```

The Javascript function `JSON.stringify` is nice for displaying an object in a V8 chunk: 

```{r, engine='V8'}
// this chunk has the option engine='V8'
JSON.stringify(double_x);
```


You can load a Javascript library as follows:

```{r}
ct$source(system.file("js/underscore.js", package="V8"))
```

As you can see, it works:

```{r, engine='V8'}
// this chunk has the option engine='V8'
JSON.stringify(_.flatten(x))
```

Another way is to give the libraries as a character vector in the `V8.libraries` chunk option:

```{r, eval=FALSE}
opts_chunk$set(V8.libraries=c(system.file("js/underscore.js", package="V8"), "http://coffeescript.org/extras/coffee-script.js"))
```

The libraries given by this way are loaded only once, at the moment the Javascript context is created.

```
